### PR TITLE
Improve preview posts logic to dont return on main page

### DIFF
--- a/scripts/create-blog.mjs
+++ b/scripts/create-blog.mjs
@@ -21,6 +21,7 @@ author:
   picture: "/assets/blog/authors/default.jpeg"
 ogImage:
   url: "/assets/blog/${slug}/cover.jpg"
+preview: true
 ---
 
 ## Introduction

--- a/src/app/_components/alert.tsx
+++ b/src/app/_components/alert.tsx
@@ -9,21 +9,14 @@ const Alert = ({ preview }: Props) => {
   return (
     <div
       className={cn('border-b dark:bg-slate-800', {
-        'bg-neutral-800 border-neutral-800 text-white': preview,
+        'bg-amber-500 border-amber-600 text-white': preview,
         'bg-neutral-50 border-neutral-200': !preview
       })}
     >
       <Container>
         {preview && (
-          <div className='py-2 text-center text-sm'>
-            This page is a preview.{' '}
-            <a
-              href='/api/exit-preview'
-              className='underline hover:text-teal-300 duration-200 transition-colors'
-            >
-              Click here
-            </a>{' '}
-            to exit preview mode.
+          <div className='py-4 text-center text-base font-medium animate-pulse'>
+            ⚠️ Preview Mode Active: This is a draft version of the content and may not reflect the final published version.
           </div>
         )}
       </Container>

--- a/src/interfaces/post.ts
+++ b/src/interfaces/post.ts
@@ -11,5 +11,5 @@ export type Post = {
     url: string
   }
   content: string
-  preview?: boolean
+  preview: boolean = false
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -18,11 +18,13 @@ export function getPostBySlug (slug: string) {
   return { ...data, slug: realSlug, content } as Post
 }
 
-export function getAllPosts (): Post[] {
+export function getAllPosts ({ includePreview = false } = {}): Post[] {
   const slugs = getPostSlugs()
   const posts = slugs
     .map(slug => getPostBySlug(slug))
     // sort posts by date in descending order
     .sort((post1, post2) => (post1.date > post2.date ? -1 : 1))
+    .filter(post => includePreview || !post.preview)
+
   return posts
 }


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/17108403-4e04-4eae-9161-21dcec6750c6)


[changelog]
changed: Do not return preview blogposts on main posts page

<!-- ps-id: 2c72e484-14ba-47c4-805e-aaff73572b02 -->